### PR TITLE
DTSPO-22647 - Test devops library branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ resources:
     type: github
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
+    ref: "DTSPO-22647/update-destination"
 
 variables:
   - name: agentPool


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-22647

### Change description ###
Pointing the pipeline to another branch on https://github.com/hmcts/cnp-azuredevops-libraries/pull/216/files
This is to test a different destination for the package 
Currently, the package gets created at `helm/pact-broker/pact-broker` which is an extra layer we might not need
Will be tested and reverted
Won't cause any issues to live as a new release is required

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
