### PR TITLE
DTSPO-28862: Update ACR references from hmctspublic to zone-redundant ACR

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
   - task: AzureCLI@2
     displayName: "Authenticate to zone-redundant ACR"
     inputs:
-      azureSubscription: "DCD-CFTAPPS-DEV"
+      azureSubscription: "DCD-CFT-Sandbox"
       scriptType: bash
       scriptLocation: inlineScript
       inlineScript: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,15 @@ jobs:
   pool:
     vmImage: ${{ variables.agentPool }}
   steps:
+  - task: AzureCLI@2
+    displayName: "Authenticate to zone-redundant ACR"
+    inputs:
+      azureSubscription: "DCD-CFTAPPS-DEV"
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        az acr login --name hmctssbox
+        
   - template: steps/charts/validate.yaml@cnp-azuredevops-libraries
     parameters:
       chartName: pact-broker

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -13,7 +13,7 @@ postgresql:
   image:
     registry: hmctssbox.azurecr.io
     repository: imported/bitnami/postgresql
-    tag: 17.5.0-debian-12-r20
+    tag: latest
   primary:
     persistence:
       enabled: false

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -11,7 +11,7 @@ postgresql:
     password: "hmcts"
     database: "hmcts"
   image:
-    registry: hmctspublic.azurecr.io
+    registry: hmctssbox.azurecr.io
     repository: imported/bitnami/postgresql
     tag: 17.5.0-debian-12-r20
   primary:

--- a/pact-broker/Chart.yaml
+++ b/pact-broker/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 dependencies:
   - name: postgresql
     version: 16.7.4
-    repository: 'oci://hmctssbox.azurecr.io/imported/bitnamicharts'
+    repository: 'oci://hmctspublic.azurecr.io/imported/bitnamicharts'
     tags:
       - postgresql-pod

--- a/pact-broker/Chart.yaml
+++ b/pact-broker/Chart.yaml
@@ -11,6 +11,6 @@ keywords:
 dependencies:
   - name: postgresql
     version: 16.7.4
-    repository: 'oci://hmctspublic.azurecr.io/imported/bitnamicharts'
+    repository: 'oci://hmctssbox.azurecr.io/imported/bitnamicharts'
     tags:
       - postgresql-pod


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-28862

### Change description ###
- Update Helm chart dependency repository in Chart.yaml
- Update PostgreSQL image registry in ci-values.yaml
- These changes point to the new zone-redundant ACR for importing dependencies

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```
